### PR TITLE
Fix for JWT & CSRF tokens, better Hash, ...

### DIFF
--- a/app/.env_app
+++ b/app/.env_app
@@ -6,6 +6,6 @@ POSTGRES_PORT=5432
 DATABASE=postgres
 
 SECRET_KEY=your_secret_key
-DEBUG=True
+DEBUG=False
 DJANGO_SETTINGS_MODULE=config.settings
 DJANGO_SUPERUSER_PASSWORD=mypassword

--- a/app/.env_app
+++ b/app/.env_app
@@ -3,6 +3,7 @@ POSTGRES_USER=myuser
 POSTGRES_PASSWORD=mypassword
 POSTGRES_HOST=db
 POSTGRES_PORT=5432
+DATABASE=postgres
 
 SECRET_KEY=your_secret_key
 DEBUG=True

--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -40,8 +40,11 @@ INSTALLED_APPS = [
 
     'corsheaders',
 	'rest_framework',
-    'home',
+    'rest_framework_simplejwt',
+    'rest_framework_simplejwt.token_blacklist',
     'csp',
+    
+    'home',
 ]
 
 MIDDLEWARE = [
@@ -86,7 +89,7 @@ CSRF_TRUSTED_ORIGINS = [
 ]
 
 CSRF_COOKIE_SECURE = True
-CSRF_COOKIE_HTTPONLY = False
+CSRF_COOKIE_HTTPONLY = True
 CSRF_USE_SESSIONS = False
 CSRF_COOKIE_NAME = 'csrftoken'
 
@@ -165,15 +168,16 @@ REST_FRAMEWORK = {
         # Adjust permissions as per your API needs
     ],
     'DEFAULT_AUTHENTICATION_CLASSES': [
+		'rest_framework_simplejwt.authentication.JWTAuthentication',
         'rest_framework.authentication.SessionAuthentication',
         'rest_framework.authentication.BasicAuthentication',
-		'rest_framework_simplejwt.authentication.JWTAuthentication',
         # Add other authentication classes as needed
     ],
 }
 
 PRIVATE_KEY_PATH = os.path.join(BASE_DIR, 'private.pem')
 PUBLIC_KEY_PATH = os.path.join(BASE_DIR, 'public.pem')
+
 SIMPLE_JWT = {
     'ALGORITHM': 'RS256',
     'SIGNING_KEY': load_key(PRIVATE_KEY_PATH),
@@ -184,9 +188,15 @@ SIMPLE_JWT = {
     'USER_ID_CLAIM': 'user_id',
     'ACCESS_TOKEN_LIFETIME': timedelta(minutes=5),
     'REFRESH_TOKEN_LIFETIME': timedelta(days=1),
-    'ROTATE_REFRESH_TOKENS': False,
+    'ROTATE_REFRESH_TOKENS': True,
     'BLACKLIST_AFTER_ROTATION': True,
     'UPDATE_LAST_LOGIN': False,
+    'AUTH_COOKIE': 'access_token',
+    'AUTH_COOKIE_REFRESH': 'refresh_token',
+    'AUTH_COOKIE_SECURE': True,
+    'AUTH_COOKIE_HTTP_ONLY': True,
+    'AUTH_COOKIE_PATH': '/',
+    'AUTH_COOKIE_SAMESITE': 'Lax',
 }
 
 PASSWORD_HASHERS = [

--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -24,7 +24,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 
 SECRET_KEY = os.environ.get("SECRET_KEY")
 
-DEBUG = bool(os.environ.get("DEBUG", default=0))
+DEBUG = os.environ.get("DEBUG")
 
 ALLOWED_HOSTS = ['*']
 
@@ -41,17 +41,19 @@ INSTALLED_APPS = [
     'corsheaders',
 	'rest_framework',
     'home',
+    'csp',
 ]
 
 MIDDLEWARE = [
+    'django.middleware.security.SecurityMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
 	'corsheaders.middleware.CorsMiddleware',
-    'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'csp.middleware.CSPMiddleware',
 ]
 
 ROOT_URLCONF = 'config.urls'
@@ -72,6 +74,10 @@ TEMPLATES = [
     },
 ]
 
+SESSION_COOKIE_SECURE = True  # Ensure session cookies are sent over HTTPS
+SESSION_COOKIE_HTTPONLY = True
+
+# CSRF
 CSRF_TRUSTED_ORIGINS = [
     'http://localhost:80',
     'https://localhost:443',
@@ -84,10 +90,7 @@ CSRF_COOKIE_HTTPONLY = False
 CSRF_USE_SESSIONS = False
 CSRF_COOKIE_NAME = 'csrftoken'
 
-
-SESSION_COOKIE_SECURE = True  # Ensure session cookies are sent over HTTPS
-SESSION_COOKIE_HTTPONLY = True
-
+# CORS
 CORS_ALLOWED_ORIGINS = [
     'http://localhost:80',
     'https://localhost:443',
@@ -194,3 +197,11 @@ PASSWORD_HASHERS = [
     # Optionally include PBKDF2SHA1 if needed for compatibility with old passwords
     # "django.contrib.auth.hashers.PBKDF2SHA1PasswordHasher",
 ]
+
+# General security practices
+SECURE_BROWSER_XSS_FILTER = True
+SECURE_CONTENT_TYPE_NOSNIFF = True
+X_FRAME_OPTIONS = 'DENY'
+
+# CSP
+CSP_DEFAULT_SRC = ("'self'",)

--- a/app/config/utils.py
+++ b/app/config/utils.py
@@ -1,0 +1,10 @@
+import os
+
+def load_key(filename):
+    if not os.path.isfile(filename):
+        raise FileNotFoundError(f"The file {filename} does not exist.")
+    
+    with open(filename, 'r') as key_file:
+        key_content = key_file.read()
+
+    return key_content

--- a/app/entrypoint.sh
+++ b/app/entrypoint.sh
@@ -25,5 +25,9 @@ python manage.py migrate --noinput
 echo "Flushing database..."
 python manage.py flush --no-input
 
+# Checks for dependencies & vulnerabilities, regularly use
+# pip install --no-cache-dir -r bandit
+# bandit -r ./
+
 echo "Starting Django development server..."
 python manage.py runserver 0.0.0.0:8000

--- a/app/entrypoint.sh
+++ b/app/entrypoint.sh
@@ -4,13 +4,17 @@ set -e  # Exit immediately if a command exits with a non-zero status
 if [ "$DATABASE" = "postgres" ]
 then
     echo "Waiting for PostgreSQL to start..."
-    while ! nc -z $SQL_HOST $SQL_PORT; do
+    while ! nc -z $POSTGRES_HOST $POSTGRES_PORT; do
         sleep 0.1
     done
     echo "PostgreSQL is up and running"
 fi
 
 python --version
+
+# Generate keys for RSA
+openssl genpkey -algorithm RSA -out private.pem -pkeyopt rsa_keygen_bits:2048
+openssl rsa -pubout -in private.pem -out public.pem
 
 # echo "Creating superuser Joe..."
 # python manage.py createsuperuser --username=joe --email=joe@example.com

--- a/app/home/csrf.py
+++ b/app/home/csrf.py
@@ -5,16 +5,25 @@ import json
 from django.middleware.csrf import get_token, CsrfViewMiddleware
 from django.views.decorators.csrf import ensure_csrf_cookie, csrf_protect, csrf_exempt
 
+@csrf_protect
 def check_csrf_token(request):
     csrf_token_from_cookie = request.COOKIES.get('csrftoken')
 
-    if csrf_token_from_cookie:
-        # Return a response indicating that the token is valid
-        return JsonResponse({'csrftoken': csrf_token_from_cookie})
-    else:
-        return JsonResponse({'status': 'off'})
+    if not csrf_token_from_cookie:
+        return JsonResponse({'status': 'off', 'message': 'No CSRF token found in cookies'})
+    
+    csrf_middleware = CsrfViewMiddleware(lambda req: None)
 
-@csrf_exempt
+    try:
+        # Create a mock request to validate the CSRF token
+        csrf_middleware.process_view(request, None, (), {})
+        return JsonResponse({'status': 'valid', 'csrftoken': csrf_token_from_cookie})
+    except Exception as e:
+        # If validation fails, clear the CSRF token cookie and request a new token
+        response = JsonResponse({'status': 'invalid', 'message': 'Invalid CSRF token'})
+        response.delete_cookie('csrftoken')
+        return response
+
 @ensure_csrf_cookie
 def get_csrf(request):
     response = JsonResponse({'detail': 'CSRF cookie set'})

--- a/app/home/urls.py
+++ b/app/home/urls.py
@@ -8,13 +8,13 @@ from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
 from . import views
 
 urlpatterns = [
-    path('api/register/', views.register_view, name='api-register'),
-    path('api/login/', views.login_view, name='api-login'),
+    path('api/register/', views.RegisterView.as_view(), name='api-register'),
+    path('api/login/', views.LoginView.as_view(), name='api-login'),
 	path('api/csrf/', views.get_csrf, name='api-csrf'),
-    path('api/logout/', views.logout_view, name='api-logout'),
+    path('api/logout/', views.LogoutView.as_view(), name='api-logout'),
 
     path('api/token/', TokenObtainPairView.as_view(), name='token_obtain_pair'),
-    path('api/token/refresh/', views.refresh_token_view, name='token_refresh_from_cookie'),
+    path('api/token/refresh/', views.CustomTokenRefreshView.as_view(), name='token_refresh'),
 
     path('api/session/', views.SessionView.as_view(), name='api-session'),  # new
     path('api/whoami/', views.WhoAmIView.as_view(), name='api-whoami'),  # new

--- a/app/home/urls.py
+++ b/app/home/urls.py
@@ -11,6 +11,7 @@ urlpatterns = [
     path('api/register/', views.RegisterView.as_view(), name='api-register'),
     path('api/login/', views.LoginView.as_view(), name='api-login'),
 	path('api/csrf/', views.get_csrf, name='api-csrf'),
+    path('api/csrf/check/', views.check_csrf_token, name='api-csrf-check'),
     path('api/logout/', views.LogoutView.as_view(), name='api-logout'),
 
     path('api/token/', TokenObtainPairView.as_view(), name='token_obtain_pair'),

--- a/app/home/views.py
+++ b/app/home/views.py
@@ -2,6 +2,7 @@ from django.shortcuts import render
 from django.http import JsonResponse
 from django.contrib.auth.models import User
 from django.contrib.auth import authenticate, login, logout
+from django.contrib.auth.hashers import make_password
 import json
 # Rest
 from rest_framework.authentication import SessionAuthentication, BasicAuthentication
@@ -54,7 +55,8 @@ def register_view(request):
         if User.objects.filter(email=email).exists():
             return JsonResponse({'message': 'Email already exists', 'status': 'error'}, status=400)
 
-        """ Todo: Hash the password """
+        
+        """ The password is hashed by default """
         user = User.objects.create_user(username=username, email=email, password=password)
         return JsonResponse({'message': 'Registration successful', 'user_id': user.id}, status=200)
 

--- a/app/home/views.py
+++ b/app/home/views.py
@@ -17,17 +17,16 @@ class SessionView(APIView):
     authentication_classes = [JWTAuthentication]
     permission_classes = [IsAuthenticated]
 
-    @staticmethod
-    def get(request, format=None):
+    @method_decorator(csrf_protect)
+    def get(self, request, format=None):
         return Response({'isAuthenticated': True})
 
 class WhoAmIView(APIView):
     authentication_classes = [JWTAuthentication]
     permission_classes = [IsAuthenticated]
 
-    @staticmethod
-    @csrf_protect
-    def get(request, format=None):
+    @method_decorator(csrf_protect)
+    def get(self, request, format=None):
         return Response({'username': request.user.username})
 
 class RegisterView(APIView):

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -6,3 +6,4 @@ djangorestframework-simplejwt
 # Security
 django[argon2]
 cryptography
+django-csp

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -3,3 +3,6 @@ psycopg2-binary
 djangorestframework
 django-cors-headers
 djangorestframework-simplejwt
+# Security
+django[argon2]
+cryptography

--- a/to-do.md
+++ b/to-do.md
@@ -5,10 +5,10 @@
 - Create Pong game in JavaScript
 
 # Back-End:
-- Hash the password
+- Hash the password [Done]
 
 # Database:
-- Protect against SQL injections/XSS
+- Protect against SQL injections/XSS [Done]
 
 # To test inside 42:
 - Check docker-compose packages
@@ -17,13 +17,13 @@
 
 IV.1 Overview
 - Web
-	- Major module: Use a Framework as backend.
-	- Minor module: Use a front-end framework or toolkit.
-	- Minor module: Use a database for the backend.
+	- Major module: Use a Framework as backend. [Done]
+	- Minor module: Use a front-end framework or toolkit. [Done]
+	- Minor module: Use a database for the backend. [Done]
 	(Optional) - Major module: Store the score of a tournament in the Blockchain.
 - User Management
 	- Major module: Standard user management, authentication, users across
-	tournaments.
+	tournaments. [2/3 Done]
 	- Major module: Implementing a remote authentication.
 - Gameplay and user experience
 	- Major module: Remote players

--- a/vue/vue-project/src/components/private/Home.vue
+++ b/vue/vue-project/src/components/private/Home.vue
@@ -46,7 +46,8 @@
 </template>
 
 <script>
-import { api } from "../../main";
+import api from "../../utils/api";
+import Cookies from 'js-cookie';
 
 export default {
   name: "loginHome",
@@ -64,7 +65,7 @@ export default {
   methods: {
     async logoutUser() {
       try {
-        const response = await api.post("/api/logout/");
+        const response = await api.post("logout/");
         console.log("Logout successful:", response.data);
         this.$router.push('/login');
       } catch (error) {
@@ -74,7 +75,8 @@ export default {
     },
     async fetchUsername() {
       try {
-        const response = await api.get("/api/whoami/"); // Example endpoint
+        const refreshToken = Cookies.get('refresh_token');
+        const response = await api.get("whoami/", { refresh: refreshToken });
         this.username = response.data.username; // Replace with your actual response structure
       } catch (error) {
         console.error("Error fetching username:", error.response ? error.response.data : error.message);

--- a/vue/vue-project/src/components/public/Login.vue
+++ b/vue/vue-project/src/components/public/Login.vue
@@ -42,7 +42,8 @@
 </template>
 
 <script>
-import { api } from "../../main";
+import { setAuthHeader } from "../../utils/auth";
+import api from "../../utils/api";
 import { validateForm } from "../../utils/form";
 import NavIndex from "./NavIndex.vue";
 
@@ -64,10 +65,12 @@ export default {
       try {
         validateForm(0, this.form);
 
-        await api.post("/api/login/", {
+        const response = await api.post("token/", {
           username: this.form.username,
           password: this.form.password,
         });
+        
+        setAuthHeader(response.data.access, response.data.refresh);
 
         this.$router.push("/home");
       } catch (error) {

--- a/vue/vue-project/src/components/public/Register.vue
+++ b/vue/vue-project/src/components/public/Register.vue
@@ -39,7 +39,7 @@
 <script>
 import NavIndex from "./NavIndex.vue";
 import { validateForm } from "../../utils/form";
-import { api } from "../../main";
+import api from "../../utils/api";
 
 export default {
   name: "CompRegister",
@@ -63,7 +63,7 @@ export default {
 
         console.log(api.defaults.headers.common['X-CSRFToken']);
         const response = await api.post(
-          "/api/register/",
+          "register/",
           {
             username: this.form.username,
             email: this.form.email,
@@ -73,7 +73,7 @@ export default {
         );
 
         console.log("Registration successful:", response.data);
-        this.$router.push('/login');
+        this.$router.push("/login");
         // Handle successful registration (e.g., show success message, redirect)
       } catch (error) {
         console.error(

--- a/vue/vue-project/src/main.js
+++ b/vue/vue-project/src/main.js
@@ -1,36 +1,22 @@
+// main.js
 import { createApp } from "vue";
 import App from "./App.vue";
-import axios from "axios";
 import router from "./router";
 import fetchAndSetCsrfToken from "./utils/csrf";
-import Cookies from 'js-cookie';
-import 'bootstrap/dist/css/bootstrap.min.css';
-import 'bootstrap/dist/js/bootstrap.bundle.min.js';
+import { setAuthHeaderFromCookie, api } from "./utils/auth"; // Import the functions from utils/auth.js
+import "bootstrap/dist/css/bootstrap.min.css";
+import "bootstrap/dist/js/bootstrap.bundle.min.js";
 import "./assets/css/styles.css";
 
+// Create Vue app
 const app = createApp(App);
 
-// Set CSRF token
-axios.defaults.xsrfHeaderName = 'X-CSRFToken'; // Default header for CSRF token
-axios.defaults.xsrfCookieName = 'csrftoken'; // Default cookie name for CSRF token
-axios.defaults.withCredentials = true;
 
-// Update the base URL for API requests
-const djangoURL = window.location.protocol + "//" + window.location.host; // Use protocol and host from the current location
-axios.defaults.baseURL = djangoURL;
-axios.defaults.timeout = 30000;
-
-const api = axios.create();
-export { api };
-
-// Fetch and set CSRF token
+// Initial setup
+setAuthHeaderFromCookie();
 fetchAndSetCsrfToken();
-
-// Set up Axios to include the JWT token in the headers
-const accessToken = Cookies.get('access_token');
-if (accessToken) {
-    axios.defaults.headers.common['Authorization'] = `Bearer ${accessToken}`;
-}
 
 app.use(router);
 app.mount("#app");
+
+export { api }; // Export the api instance

--- a/vue/vue-project/src/utils/api.js
+++ b/vue/vue-project/src/utils/api.js
@@ -1,0 +1,49 @@
+// utils/api.js
+import Cookies from "js-cookie";
+import axios from "axios";
+import { setAuthHeaderFromCookie } from "./auth";
+
+// Create an Axios instance
+const api = axios.create({
+  baseURL: '/api/',
+  timeout: 30000,
+  withCredentials: true, // Ensure cookies are sent with requests
+  xsrfHeaderName: "X-CSRFToken",
+  xsrfCookieName: "csrftoken",
+});
+
+// Interceptor to handle token refresh
+api.interceptors.response.use(
+  response => response,
+  async error => {
+    const originalRequest = error.config;
+    if (error.response.status === 401 && !originalRequest._retry) {
+      originalRequest._retry = true;
+      try {
+        const refreshToken = Cookies.get("refresh_token");
+        if (refreshToken) {
+          const response = await api.post("/api/token/refresh/", { refresh: refreshToken });
+          const newAccessToken = response.data.access;
+          Cookies.set("access_token", newAccessToken, { secure: true, sameSite: "Lax" });
+          setAuthHeaderFromCookie();
+          originalRequest.headers["Authorization"] = `Bearer ${newAccessToken}`;
+          return api(originalRequest);
+        }
+      } catch (err) {
+        if (err.response && err.response.status === 401) {
+          // Refresh token is also invalid, log the user out
+          console.error("Refresh token is invalid", err);
+          Cookies.remove("access_token");
+          Cookies.remove("refresh_token");
+          window.location.href = "/login";  // Redirect to login page
+        } else {
+          console.error("Failed to refresh token", err);
+        }
+        return Promise.reject(error);
+      }
+    }
+    return Promise.reject(error);
+  }
+);
+
+export default api;

--- a/vue/vue-project/src/utils/auth.js
+++ b/vue/vue-project/src/utils/auth.js
@@ -5,8 +5,8 @@ import api from "./api";
 export function setAuthHeader(accessToken, refreshToken) {
   if (accessToken && refreshToken) {
     api.defaults.headers.common["Authorization"] = `Bearer ${accessToken}`;
-    Cookies.set('refresh_token', refreshToken, { expires: 7, secure: true, sameSite: 'Lax' });
-    Cookies.set('access_token', accessToken, { expires: 7, secure: true, sameSite: 'Lax' });
+    Cookies.set('refresh_token', refreshToken, { secure: true, sameSite: 'Lax' });
+    Cookies.set('access_token', accessToken, { secure: true, sameSite: 'Lax' });
   }
 }
 

--- a/vue/vue-project/src/utils/auth.js
+++ b/vue/vue-project/src/utils/auth.js
@@ -1,23 +1,53 @@
 // utils/auth.js
-import { api } from "../main";
-// import Cookies from 'js-cookie';
+import Cookies from "js-cookie";
+import api from "./api";
 
+export function setAuthHeader(accessToken, refreshToken) {
+  if (accessToken && refreshToken) {
+    api.defaults.headers.common["Authorization"] = `Bearer ${accessToken}`;
+    Cookies.set('refresh_token', refreshToken, { expires: 7, secure: true, sameSite: 'Lax' });
+    Cookies.set('access_token', accessToken, { expires: 7, secure: true, sameSite: 'Lax' });
+  }
+}
+
+// Function to set Authorization header
+export function setAuthHeaderFromCookie() {
+  const accessToken = Cookies.get("access_token");
+  if (accessToken) {
+    api.defaults.headers.common["Authorization"] = `Bearer ${accessToken}`;
+  } else {
+    delete api.defaults.headers.common["Authorization"];
+  }
+}
+
+// Function to refresh auth token
 export async function refreshAuthToken() {
   try {
-    const response = await api.post("/api/token/refresh/");
-    console.log(response);
+    const refreshToken = Cookies.get('refresh_token');
+    if (!refreshToken) {
+      throw new Error('No refresh token available');
+    }
+
+    const response = await api.post('token/refresh/', { refresh: refreshToken });
+    const newAccessToken = response.data.access;
+    const newRefreshToken = response.data.refresh;
+
+    // Update the Authorization header with the new token
+    setAuthHeader(newAccessToken, newRefreshToken);
+
     return true;
-  }
-  catch (error) {
+  } catch (error) {
     console.error(
-      "Login error:",
+      "Refresh token error:",
       error.response ? error.response.data : error.message
     );
-    // Handle login error (e.g., show error message to user)
+    // Handle refresh token error (e.g., log out the user)
     alert(
-      "Login failed. " +
+      "Session expired. Please log in again. " +
         (error.response ? error.response.data.detail : error.message)
     );
     return false;
   }
 }
+
+export { api };

--- a/vue/vue-project/src/utils/csrf.js
+++ b/vue/vue-project/src/utils/csrf.js
@@ -1,5 +1,5 @@
 import Cookies from 'js-cookie';
-import { api } from '../main'; // Import the api instance from main.js
+import api from './api'; // Import the api instance from main.js
 
 // Function to get CSRF token from cookies using js-cookie
 function getCsrfToken() {
@@ -12,7 +12,7 @@ async function checkCSRF() {
   
     if (csrfToken) {
         try {
-            const response = await api.get("/api/csrf/");
+            const response = await api.get("csrf/");
             if (response.data.status === "off") {
                 console.log("CSRF token is invalid or expired");
                 Cookies.remove('csrftoken', { path: '/' });
@@ -40,11 +40,12 @@ export default async function fetchAndSetCsrfToken() {
         console.log('No valid CSRF tokens were found');
 
         // Fetch new CSRF token from the server
-        const response = await api.get("/api/csrf/");
+        const response = await api.get("csrf/");
         const csrfToken = response.headers["x-csrftoken"];
 
         // Set CSRF token in Axios defaults and cookies
         api.defaults.headers.common['X-CSRFToken'] = csrfToken;
+        Cookies.set("csrftoken", csrfToken, { secure: true, sameSite: "Lax" });
     } catch (error) {
         console.error("Error fetching CSRF token:", error);
         throw error;


### PR DESCRIPTION
- Use safer password hashers
- Integrate Database correctly & test saving user data
- Make use of RSA256 for JWT Auth, safer than default (HS256)
- Create two keys for RSA256 inside Backend container
- Integrate JWT in Register, Login & data Fetch functions
- Handle JWT & CSRF correctl & safely, protection for XSS attacks, Token Theft & CSRF
- Test 'bandit', used for audit inside Backend for dependencies & vulnerabilities